### PR TITLE
Fix crash when there is no data to draw from

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,34 +7,8 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@master
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+    - uses: SuffolkLITLab/ALActions/publish@main
       with:
-        python-version: 3.9
-    - name: Install pypa/build
-      run: >-
-        python -m
-        pip install
-        build
-        --user
-    - name: Check syntax for all files
-      run: >-
-        python -m
-        compileall
-        .
-        -q
-    - name: Build a binary wheel and a source tarball
-      run: >-
-        python -m
-        build
-        --sdist
-        --wheel
-        --outdir dist/
-    - name: Publish distribution 📦 to PyPI
-      if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
-
+        PYPY_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        VERSION_TO_PUBLISH: ${{ env.GITUB_REF_NAME }}
+        TEAMS_BUMP_WEBHOOK: ${{ secrets.TEAMS_BUMP_WEBHOOK }}

--- a/docassemble/InterviewStats/snapshot_geography.py
+++ b/docassemble/InterviewStats/snapshot_geography.py
@@ -101,7 +101,11 @@ def make_bokeh_map(geosource, geo_loc_counts, col_name: str='zip'):
     # Settled on brewer for colors: https://colorbrewer2.org
     # Was considering `colorcet`, but https://arxiv.org/pdf/1509.03700v1.pdf says stick with brewer
     palette = list(reversed(brewer['YlGnBu'][5]))  # Gets yellow as low and blue as high
-    max_val = max(geo_loc_counts[col_name + '_counts'])
+    vals = geo_loc_counts[col_name + '_counts']
+    if vals.empty:
+        max_val = 10
+    else:
+        max_val = max(vals)
     color_mapper = LinearColorMapper(palette=palette, low=0, high=max_val)
     map_plot.patches('xs', 'ys', source=geosource,
                      fill_color={'field': col_name + '_counts', 'transform': color_mapper},


### PR DESCRIPTION
The issue is that if there's no data, there's nothing to iterate over when looking for the max value to color the range. In this case, we can simply avoid that range.

Also updates the github workflow to use ALActions.