### PR TITLE
Remove session id

### DIFF
--- a/docassemble/InterviewStats/data/questions/stats.yml
+++ b/docassemble/InterviewStats/data/questions/stats.yml
@@ -190,7 +190,7 @@ need: stats
 code: |
   columns = get_columns(stats)
   my_col = next(iter(columns), None)
-  groupable_columns = list(set(columns).difference(set(['modtime', 'user_session_id'])))
+  groupable_columns = list(set(columns).difference(set(['modtime'])))
   possible_states = get_column_values(stats, 'state')
 ---
 code: |

--- a/docassemble/InterviewStats/snapshot_statistics.py
+++ b/docassemble/InterviewStats/snapshot_statistics.py
@@ -52,14 +52,13 @@ def get_stats(filename: str, column:str=None):
     conn = variables_snapshot_connection()
     with conn.cursor() as cur:
         # use a parameterized query to prevent SQL injection
-        query = "select modtime, data, key, tags from jsonstorage where filename=%(filename)s"
+        query = "select modtime, data, tags from jsonstorage where filename=%(filename)s"
         cur.execute(query, {'filename': filename})
         records = list()
         for record in cur:
             # Add modtime to the all stats
             record[1]['modtime'] = record[0]
-            record[1]['user_session_id'] = record[2]
-            record[1]['user_defined_tags'] = record[3]
+            record[1]['user_defined_tags'] = record[2]
             if column:
                 if column in record[1]:
                     records.append(record[1][column])


### PR DESCRIPTION
Was added for some reason in https://github.com/SuffolkLITLab/docassemble-InterviewStats/commit/33234abd2112dcf73ebd594b1530ad79bd241a05, my only guess as to why is that we needed to display the user defined tags, and docassemble internally calls that a key. So likely the first implementation tried to get the key from the JSON table, but it was the wrong value, and was never removed?

Should be able to remove it without harm, but TBH it's concerning that the session id is just there. Would be nice to patch upstream to be the hash, which seems like the best alternative.