### PR TITLE
Force numpy<2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.InterviewStats',
       url='https://courtformsonline.org/about/',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['bokeh>=2.4.2', 'cenpy>=1.0.0.post4', 'geopandas>=0.9.0', 'numpy>=1.0.4', 'pandas>=1.4.2', 'requests>=2.27.1'],
+      install_requires=['bokeh>=2.4.2', 'cenpy>=1.0.0.post4', 'geopandas>=0.9.0', 'numpy>=1.0.4,<2.0.0', 'pandas>=1.4.2', 'requests>=2.27.1'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/InterviewStats/', package='docassemble.InterviewStats'),
      )


### PR DESCRIPTION
Numpy released 2.0.0 this weekend, which has breaking changes from 1.0.0, and is likely to break anything using it. We should probably stick with 1.x.y for now.

(Making this change while waiting to build FormFyxer, which is actually broken due to Numpy 2.0.0, more info coming in a PR there. ~Will merge if this builds as normal / passes any GH actions~ there are no GH actions here, so likely won't merge since I don't have time to verify it builds / can install on DA fine still).