### PR TITLE
Add optional date-range filter to interview stats query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 docassemble/InterviewStats/data/sources/*.zip
 *.egg-info
 dist/**
+.DS_Store

--- a/docassemble/InterviewStats/data/questions/stats.yml
+++ b/docassemble/InterviewStats/data/questions/stats.yml
@@ -290,13 +290,22 @@ fields:
     datatype: combobox
     code: |
       get_combined_filename_list()
+  - Filter by date range?: filter_by_date
+    datatype: yesno
+    default: False
+  - From date: stats_date_from
+    datatype: date
+    show if: filter_by_date
+  - To date: stats_date_to
+    datatype: date
+    show if: filter_by_date
 ---
 code: |
   if filename is not None:
     if 'data/questions' in filename or 'playground' in filename:
-      stats = get_stats(filename)
+      stats = get_stats(filename, date_from=stats_date_from if filter_by_date else None, date_to=stats_date_to if filter_by_date else None)
     else:
-      stats = get_stats(filename.replace(':',':data/questions/'))
+      stats = get_stats(filename.replace(':',':data/questions/'), date_from=stats_date_from if filter_by_date else None, date_to=stats_date_to if filter_by_date else None)
   else:
     no_interview_stats
 ---

--- a/docassemble/InterviewStats/data/questions/stats.yml
+++ b/docassemble/InterviewStats/data/questions/stats.yml
@@ -140,7 +140,7 @@ code: |
   background_response()
 ---
 code: |
-  summary_stats = get_summary_stats(filename)
+  summary_stats = get_summary_stats(filename, date_from=stats_date_from if filter_by_date else None, date_to=stats_date_to if filter_by_date else None)
 ---
 reconsider: summary_stats
 question: |
@@ -423,6 +423,7 @@ question: |
 subquestion: |
   Total submissions: ${ len(stats) }
 
+  % if len(stats):
   Group by:
   % for col in groupable_columns:
   [${col}](${ url_action('show_grouped_data', group_by = col)  })
@@ -431,6 +432,9 @@ subquestion: |
   ${ formatted_data.groupby(by=my_col).count().to_html(classes=('table','table-striped')) }
 
   [:file-excel: Download](${ url_ask('generate_excel') })
+  % else:
+  No records found for this date range. Try a wider range or clear the date filter.
+  % endif
 # under: |
 #   ${ map_div }
 # script: |

--- a/docassemble/InterviewStats/snapshot_statistics.py
+++ b/docassemble/InterviewStats/snapshot_statistics.py
@@ -165,7 +165,7 @@ def get_overall_stats():
     return val
 
 
-def get_stats(filename: str, column: str = None):
+def get_stats(filename: str, column: str = None, date_from=None, date_to=None):
     conn = variables_snapshot_connection()
     with conn.cursor() as cur:
         # use a parameterized query to prevent SQL injection
@@ -180,7 +180,14 @@ def get_stats(filename: str, column: str = None):
                    WHERE filename=%(filename)s
                    AND 
                    tags IS DISTINCT FROM 'metadata'"""
-        cur.execute(query, {"filename": filename})
+        params = {"filename": filename}
+        if date_from is not None:
+            query += " AND modtime >= %(date_from)s"
+            params["date_from"] = date_from
+        if date_to is not None:
+            query += " AND modtime <= %(date_to)s"
+            params["date_to"] = date_to
+        cur.execute(query, params)
         records = list()
         for record in cur:
             # Add modtime to the all stats

--- a/docassemble/InterviewStats/snapshot_statistics.py
+++ b/docassemble/InterviewStats/snapshot_statistics.py
@@ -86,7 +86,7 @@ def shorten_filename(filename: str, max_length: int = 20) -> str:
     return name
 
 
-def get_summary_stats(filename: str):
+def get_summary_stats(filename: str, date_from=None, date_to=None):
     conn = variables_snapshot_connection()
     with conn.cursor() as cur:
         query = """SELECT 
@@ -98,7 +98,14 @@ def get_summary_stats(filename: str):
                     AND 
                     tags IS DISTINCT FROM 'metadata'
                 """
-        cur.execute(query, {"filename": filename})
+        params = {"filename": filename}
+        if date_from is not None:
+            query += " AND modtime >= %(date_from)s"
+            params["date_from"] = date_from
+        if date_to is not None:
+            query += " AND modtime < %(date_to)s"
+            params["date_to"] = date_to + datetime.timedelta(days=1)
+        cur.execute(query, params)
         val = cur.fetchone()
     conn.close()
     return val

--- a/docassemble/InterviewStats/snapshot_statistics.py
+++ b/docassemble/InterviewStats/snapshot_statistics.py
@@ -1,3 +1,4 @@
+import datetime
 from docassemble.base.util import variables_snapshot_connection, interview_menu, log
 from docassemble.webapp.db_object import init_sqlalchemy
 from sqlalchemy.sql import text
@@ -185,8 +186,11 @@ def get_stats(filename: str, column: str = None, date_from=None, date_to=None):
             query += " AND modtime >= %(date_from)s"
             params["date_from"] = date_from
         if date_to is not None:
-            query += " AND modtime <= %(date_to)s"
-            params["date_to"] = date_to
+            # date_to is a plain date (no time), so treat it as "through the
+            # end of that day" rather than midnight - otherwise anything
+            # saved after midnight on the To date gets excluded
+            query += " AND modtime < %(date_to)s"
+            params["date_to"] = date_to + datetime.timedelta(days=1)
         cur.execute(query, params)
         records = list()
         for record in cur:


### PR DESCRIPTION
This fixes #39. The problem started with MLH, when their PPO interview has accumulated large amount of saved snapshot rows, and the stats dashboard just times out trying to load and export all of it at once. The old code `(get_stats())`  pulled every row for an interview with no way to narrow it down, so the more data an org collects over time, the more likely this breaks.

This adds an optional date range to the interview-selection screen. If someone checks "Filter by date range?" and picks a from/to date, that range gets pushed into the actual SQL query, so the database only sends back the rows that are actually needed - instead of pulling everything and filtering it. If nobody uses the filter, everything works exactly like before.