### PR TITLE
Cap the grouped stats table at 50 rows

### DIFF
--- a/docassemble/InterviewStats/data/questions/stats.yml
+++ b/docassemble/InterviewStats/data/questions/stats.yml
@@ -410,7 +410,15 @@ subquestion: |
   [${col}](${ url_action('show_grouped_data', group_by = col)  })
   % endfor
 
-  ${ formatted_data.groupby(by=my_col).count().to_html(classes=('table','table-striped')) }
+  <%
+    grouped = formatted_data.groupby(by=my_col).count()
+    grouped = grouped.sort_values(grouped.columns[0], ascending=False)
+    total_groups = len(grouped)
+  %>
+  % if total_groups > 50:
+  Showing the top 50 of ${ total_groups } groups by count. Download the Excel file below for the full breakdown.
+  % endif
+  ${ grouped.head(50).to_html(classes=('table','table-striped')) }
 
   [:file-excel: Download](${ url_ask('generate_excel') })
   % else:

--- a/docassemble/InterviewStats/data/questions/test_create_snapshot_data.yml
+++ b/docassemble/InterviewStats/data/questions/test_create_snapshot_data.yml
@@ -20,8 +20,8 @@ code: |
   if what_to_do == 'generate':
     number_of_data_points
     # Edit your data here
-    ma_zips = ['01001', '01002', '02330', '02332', '02771', '027771',
-      '02125', '02122', '02124', '02123', '02115', '02116']
+    ma_zips = list(set([f'{random.randint(75001, 79999):05}' for _ in range(300)])) \
+        + list(set([f'{random.randint(1001,2799):05}' for _ in range(300)]))
     def my_generator():
       for _ in range(number_of_data_points):
         yield {'zip': random.choice(ma_zips), 'state': 'MA'}


### PR DESCRIPTION
Fixes part of #46. The stats page was rendering every single group into one table, which made the page unusable for interviews with a lot of data.

Now it only shows the top 50 groups by count, with a note when there's more, and points to the existing Excel download for the rest.

(Still investigating the other part of #46 - the slow initial page load separately.)

