### PR TITLE
Speed up the stats page load

### DIFF
--- a/docassemble/InterviewStats/data/questions/stats.yml
+++ b/docassemble/InterviewStats/data/questions/stats.yml
@@ -176,7 +176,6 @@ continue button field: simple_data
 code: |
   overall_stats = get_overall_stats()
   summary_by_filename = get_summary_stats_by_filename()
-  session_overall_stats = get_session_overall_stats()
   session_summary_by_filename = get_session_summary_stats_by_filename()
 ---
 id: what-interview-do-you-want-to-view-statistics-for
@@ -197,20 +196,8 @@ under: |
   on your server and interviews.
 
   Total sessions with saved statistics across all interviews: ${ overall_stats[0] }
-  
-  <div class="stats-tabs">
-    <ul class="nav nav-tabs" id="stats-tabs">
-      <li class="nav-item">
-        <a href="#" class="nav-link active" id="snapshots-tab">Snapshots</a>
-      </li>
-      <li class="nav-item">
-        <a href="#" class="nav-link" id="sessions-tab">All sessions</a>
-      </li>
-    </ul>
-  </div>
 
   % if summary_by_filename:
-  <div id="snapshots-panel">
   <div style="margin-bottom:0.5rem">
     <a href="${ url_ask('generate_summary_excel') }" class="btn btn-link">
       <i class="fa fa-file-excel" aria-hidden="true"></i>
@@ -244,19 +231,39 @@ under: |
     % endfor
     </tbody>
   </table>
-  </div>
-
-  
   % endif
+
+  <p><a href="${ url_ask('session_data_screen') }">View all sessions by interview title</a></p>
+fields:
+  - Filename: filename
+    datatype: combobox
+    code: |
+      get_combined_filename_list()
+  - Filter by date range?: filter_by_date
+    datatype: yesno
+    default: False
+  - From date: stats_date_from
+    datatype: date
+    show if: filter_by_date
+  - To date: stats_date_to
+    datatype: date
+    show if: filter_by_date
+---
+code: |
+  session_summary_by_filename = get_session_summary_stats_by_filename()
+---
+event: session_data_screen
+id: session-data-screen
+question: |
+  All sessions by interview title
+subquestion: |
   % if session_summary_by_filename:
-  <div id="sessions-panel" style="display:none;">
   <div style="margin-bottom:0.5rem">
     <a href="${ url_ask('generate_sessions_excel') }" class="btn btn-link">
       <i class="fa fa-file-excel" aria-hidden="true"></i>
       Download session summary
     </a>
   </div>
-  <h2 class="h4">All sessions by interview title</h2>
   <table id="sessions-table" class="table table-striped table-bordered sortable">
     <thead>
       <tr>
@@ -275,28 +282,17 @@ under: |
         <td>${ row.get('count_30d', 0) }</td>
         <td>${ row.get('count_90d', 0) }</td>
         <td>${ row.get('count_365d', 0) }</td>
-  <td>${ row.get('count_all', 0) }</td>
-  <td>${ format_date(row.get('max_all'), format='MM/dd/yyyy') if row.get('max_all') else '' }</td>
+        <td>${ row.get('count_all', 0) }</td>
+        <td>${ format_date(row.get('max_all'), format='MM/dd/yyyy') if row.get('max_all') else '' }</td>
       </tr>
     % endfor
     </tbody>
   </table>
-  </div>
+  % else:
+  No session data found.
   % endif
-fields:
-  - Filename: filename
-    datatype: combobox
-    code: |
-      get_combined_filename_list()
-  - Filter by date range?: filter_by_date
-    datatype: yesno
-    default: False
-  - From date: stats_date_from
-    datatype: date
-    show if: filter_by_date
-  - To date: stats_date_to
-    datatype: date
-    show if: filter_by_date
+
+  [Back to summary](${ url_ask('filename') })
 ---
 code: |
   if filename is not None:

--- a/docassemble/InterviewStats/data/static/sortable.js
+++ b/docassemble/InterviewStats/data/static/sortable.js
@@ -49,38 +49,8 @@
     });
   }
 
-
-  function setupTabs(){
-    var snapTab = document.getElementById('snapshots-tab');
-    var sessTab = document.getElementById('sessions-tab');
-    var snapPanel = document.getElementById('snapshots-panel');
-    var sessPanel = document.getElementById('sessions-panel');
-    if(!snapTab || !sessTab || !snapPanel || !sessPanel) return;
-    if(!snapTab._daTabAttached){
-      snapTab._daTabAttached = true;
-      snapTab.addEventListener('click', function(e){
-        e.preventDefault();
-        snapTab.classList.add('active');
-        sessTab.classList.remove('active');
-        snapPanel.style.display = '';
-        sessPanel.style.display = 'none';
-      });
-    }
-    if(!sessTab._daTabAttached){
-      sessTab._daTabAttached = true;
-      sessTab.addEventListener('click', function(e){
-        e.preventDefault();
-        sessTab.classList.add('active');
-        snapTab.classList.remove('active');
-        sessPanel.style.display = '';
-        snapPanel.style.display = 'none';
-      });
-    }
-  }
-
 $(document).on('daPageLoad', function(){
     var tables = document.querySelectorAll('table.sortable');
     Array.prototype.forEach.call(tables, makeSortable);
-    setupTabs();
 });
 })();


### PR DESCRIPTION
Part of #46

Removes a query that was not used, and moves the session data (the hidden All Sessions tab) to its own page so
it only loads when someone clicks it, instead of on every page load. Two of the four queries that used to fire upfront are removed from the main page now.